### PR TITLE
allow cname redirects at the base

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-apsa-meeting.github.io/coming-soon
+apsa-meeting.github.io


### PR DESCRIPTION
This should allow an APSA-specific CNAME to reference all past meetings as "folders" now.